### PR TITLE
changes to relative and simple calib file path

### DIFF
--- a/yujin_lidar_rosmelodic_driver_ubuntu1804/yujin_yrl_package/src/yrl_pub.cpp
+++ b/yujin_lidar_rosmelodic_driver_ubuntu1804/yujin_yrl_package/src/yrl_pub.cpp
@@ -95,7 +95,7 @@ int main(int argc, char **argv)
     /// Set LiDAR's IP address as an input IP address for driver
     instance->setInputIpAddress("192.168.1.250");
     /// Set LiDAR's Calibration File Path
-    instance->setCalibrationFilePath("/home/jykim/catkin_ws/lk_serial_no.bin");
+    instance->setCalibrationFilePath("lk.bin");
     
     /// Simple parameter set functions
     instance->setSensorHeight(1.5); /// sensor at 1.5m height. The default height when the sensor is on ground is 0.07m


### PR DESCRIPTION
To support a better out-of-the-box experience, e.g. as described by the new ROS tutorial: http://wiki.ros.org/yujin_yrl_package/Tutorials/Running%20the%20YRL.

Background: The currently used path is absolute. For using the ROS driver without touching the source code the current file path would need to be recreated exactly, which could lead to a significant effort. Using a relative file path enables the driver to pick up calibration files located in the folder from where to the driver is executed.